### PR TITLE
Added config file linux path support, fixes #4

### DIFF
--- a/src/main/java/com/rebelkeithy/deeppockets/config/ConfigLoader.java
+++ b/src/main/java/com/rebelkeithy/deeppockets/config/ConfigLoader.java
@@ -5,15 +5,16 @@ import com.google.gson.GsonBuilder;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.*;
+import java.nio.file.Path;
 
 public class ConfigLoader {
-    private static final String CONFIG_DIR = FabricLoader.getInstance().getConfigDir() + "\\";
+    private static final Path CONFIG_DIR = FabricLoader.getInstance().getConfigDir();
 
     public Config loadConfigFile(String filename) {
         Config config;
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         try {
-            config = gson.fromJson(new FileReader(new File(CONFIG_DIR, filename)), Config.class);
+            config = gson.fromJson(new FileReader(CONFIG_DIR.resolve(filename).toString()), Config.class);
         } catch (FileNotFoundException e) {
             System.out.println("Generating config file for mod: toughness bars.");
             config = new Config();
@@ -24,7 +25,7 @@ public class ConfigLoader {
 
     public void saveConfigFile(String filename, Config config) {
         try {
-            var writer = new FileWriter(CONFIG_DIR + filename);
+            var writer = new FileWriter(CONFIG_DIR.resolve(filename).toString());
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             gson.toJson(config, writer);
             writer.flush();


### PR DESCRIPTION
Fixes non windows config fiel pathing from generating on hardcoded backslash path "config\deep-pockets-config.json".